### PR TITLE
Resolve daemon warnings for threading methods

### DIFF
--- a/cli/polyaxon/_client/workers/base_worker.py
+++ b/cli/polyaxon/_client/workers/base_worker.py
@@ -31,7 +31,7 @@ class BaseWorker:
         try:
             if not self.is_alive():
                 self._thread = threading.Thread(target=self._target, name=self.NAME)
-                self._thread.setDaemon(True)
+                self._thread.daemon = True
                 self._thread.start()
                 self._thread_for_pid = os.getpid()
         finally:


### PR DESCRIPTION
# PR Summary
This small PR resolve the deprecation warnings of daemon for threading methods:
```python
/home/runner/work/polyaxon/polyaxon/cli/cli/polyaxon/_client/workers/base_worker.py:34: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
```